### PR TITLE
Fix cluster mode description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ $ redis-cli -h 127.0.0.1 -p 7617 get test
 ```bash
 $ pkill -f predixy
 ```
-## Instacart Local Development Instructions (Cluster mode disabled)
+## Instacart Local Development Instructions (Cluster mode enabled)
 
 ### Setting up Redis Cluster Locally
 


### PR DESCRIPTION
Cursor edited the original README update to have the setting incorrectly documented and this was missed, this PR fixes that. 